### PR TITLE
Refactor visualize.py to return results from asyncio calls

### DIFF
--- a/langchain_visualizer/visualize.py
+++ b/langchain_visualizer/visualize.py
@@ -62,8 +62,8 @@ def visualize(fn: FunctionBasedRecipe):
             self._mode = mode
             if trace:
                 enable_trace()
-            asyncio.run(untraced_wrapper(*args, **kwargs))
+            return asyncio.run(untraced_wrapper(*args, **kwargs))
 
-        cli()
+        return cli()
 
     return new_main(recipe, fn)


### PR DESCRIPTION
Problem:
- In scenarios where multiple agents are chained together, it is crucial to pass the output of one agent's execution to the next. Currently, the `visualize` function in `visualize.py` does not return any result, hindering this process.

Solution:
- Modify `visualize` function in `visualize.py` to return the result of `asyncio.run(untraced_wrapper(*args, **kwargs))`.
- Ensure `cli()` function also returns its result in `visualize.py`.